### PR TITLE
Make OpenCL device selection and RUN_ON_CPU configurable

### DIFF
--- a/OpenCL/datamining/correlation/correlation.c
+++ b/OpenCL/datamining/correlation/correlation.c
@@ -23,8 +23,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "correlation.h"
 #include <polybench.h>
@@ -69,7 +67,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int m, int n, DATA_TYPE POLYBENCH_2D(symmat, M, N, m, n), DATA_TYPE POLYBENCH_2D(symmat_outputFromGpu, M, N, m, n))
@@ -423,7 +420,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, symmat_mem_obj, CL_TRUE, 0, M * N * sizeof(DATA_TYPE), POLYBENCH_ARRAY(symmat_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/datamining/covariance/covariance.c
+++ b/OpenCL/datamining/covariance/covariance.c
@@ -23,8 +23,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "covariance.h"
 #include <polybench.h>
@@ -69,7 +67,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int m, int n, DATA_TYPE POLYBENCH_2D(symmat,M,M,m,m), DATA_TYPE POLYBENCH_2D(symmat_outputFromGpu,M,M,m,m))
@@ -361,7 +358,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, symmat_mem_obj, CL_TRUE, 0, M * N * sizeof(DATA_TYPE), POLYBENCH_ARRAY(symmat_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");   
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/2mm/2mm.c
+++ b/OpenCL/linear-algebra/kernels/2mm/2mm.c
@@ -23,8 +23,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "2mm.h"
 #include <polybench.h>
@@ -65,7 +63,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, int nl, DATA_TYPE POLYBENCH_2D(D, NI, NL, ni, nl), DATA_TYPE POLYBENCH_2D(D_outputFromGpu, NI, NL, ni, nl))
@@ -379,7 +376,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/3mm/3mm.c
+++ b/OpenCL/linear-algebra/kernels/3mm/3mm.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "3mm.h"
 #include <polybench.h>
@@ -66,7 +64,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, int nl, DATA_TYPE POLYBENCH_2D(G, NI, NL, ni, nl), DATA_TYPE POLYBENCH_2D(G_outputFromGpu, NI, NL, ni, nl))
@@ -400,7 +397,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, g_mem_obj, CL_TRUE, 0, sizeof(DATA_TYPE) * NI * NL, POLYBENCH_ARRAY(G_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/atax/atax.c
+++ b/OpenCL/linear-algebra/kernels/atax/atax.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "atax.h"
 #include <polybench.h>
@@ -66,7 +64,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ny, DATA_TYPE POLYBENCH_1D(z,NY,ny), DATA_TYPE POLYBENCH_1D(z_outputFromGpu,NY,ny))
@@ -316,7 +313,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, y_mem_obj, CL_TRUE, 0, NY*sizeof(DATA_TYPE), POLYBENCH_ARRAY(y_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/bicg/bicg.c
+++ b/OpenCL/linear-algebra/kernels/bicg/bicg.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "bicg.h"
 #include <polybench.h>
@@ -67,7 +65,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int nx, int ny, DATA_TYPE POLYBENCH_1D(s,NY,ny), DATA_TYPE POLYBENCH_1D(s_outputFromGpu,NY,ny), 
@@ -343,7 +340,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, q_mem_obj, CL_TRUE, 0, NX*sizeof(DATA_TYPE), POLYBENCH_ARRAY(q_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");  
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/doitgen/doitgen.c
+++ b/OpenCL/linear-algebra/kernels/doitgen/doitgen.c
@@ -39,7 +39,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 #define MAX_SOURCE_SIZE (0x100000)
 
@@ -352,7 +351,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, c_mem_obj, CL_TRUE, 0, NR * NQ * NP * sizeof(DATA_TYPE), sum_outputFromGpu, 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/gemm/gemm.c
+++ b/OpenCL/linear-algebra/kernels/gemm/gemm.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "gemm.h"
 #include <polybench.h>
@@ -58,7 +56,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, int nj, DATA_TYPE POLYBENCH_2D(C,NI,NJ,ni,nj), DATA_TYPE POLYBENCH_2D(C_outputFromGpu,NI,NJ,ni,nj))
@@ -313,7 +310,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/gemver/gemver.c
+++ b/OpenCL/linear-algebra/kernels/gemver/gemver.c
@@ -21,8 +21,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "gemver.h"
 #include <polybench.h>
@@ -68,7 +66,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_1D(w1, N, n), DATA_TYPE POLYBENCH_1D(w2, N, n))
@@ -410,7 +407,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, w_mem_obj, CL_TRUE, 0, N*sizeof(DATA_TYPE), POLYBENCH_ARRAY(w_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 	
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/gesummv/gesummv.c
+++ b/OpenCL/linear-algebra/kernels/gesummv/gesummv.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "gesummv.h"
 #include <polybench.h>
@@ -64,7 +62,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_1D(y,N,n), DATA_TYPE POLYBENCH_1D(y_outputFromGpu,N,n))
@@ -305,7 +302,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, y_mem_obj, CL_TRUE, 0, N*sizeof(DATA_TYPE), POLYBENCH_ARRAY(y_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/mvt/mvt.c
+++ b/OpenCL/linear-algebra/kernels/mvt/mvt.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "mvt.h"
 #include <polybench.h>
@@ -63,7 +61,6 @@ size_t source_size;
 const int LIST_SIZE = N;
 char str_temp[1024];
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_1D(x1, N, n), DATA_TYPE POLYBENCH_1D(x1_outputFromGpu, N, n), DATA_TYPE POLYBENCH_1D(x2, N, n), DATA_TYPE POLYBENCH_1D(x2_outputFromGpu, N, n))
@@ -322,7 +319,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, x2_mem_obj, CL_TRUE, 0, N*sizeof(DATA_TYPE), POLYBENCH_ARRAY(x2_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");   
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/syr2k/syr2k.c
+++ b/OpenCL/linear-algebra/kernels/syr2k/syr2k.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "syr2k.h"
 #include <polybench.h>
@@ -67,7 +65,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, DATA_TYPE POLYBENCH_2D(C, NI, NI, ni, ni), DATA_TYPE POLYBENCH_2D(C_outputFromGpu, NI, NI, ni, ni))
@@ -325,7 +322,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/kernels/syrk/syrk.c
+++ b/OpenCL/linear-algebra/kernels/syrk/syrk.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "syrk.h"
 #include <polybench.h>
@@ -63,7 +61,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, DATA_TYPE POLYBENCH_2D(C, NI, NI, ni, ni), DATA_TYPE POLYBENCH_2D(C_outputFromGpu, NI, NI, ni, ni))
@@ -309,7 +306,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, c_mem_obj, CL_TRUE, 0, NI * NJ * sizeof(DATA_TYPE), POLYBENCH_ARRAY(C_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");  
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/solvers/gramschmidt/gramschmidt.c
+++ b/OpenCL/linear-algebra/solvers/gramschmidt/gramschmidt.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "gramschmidt.h"
 #include <polybench.h>
@@ -64,7 +62,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, int nj, DATA_TYPE POLYBENCH_2D(A,NI,NJ,ni,nj), DATA_TYPE POLYBENCH_2D(A_outputFromGpu,NI,NJ,ni,nj))
@@ -369,7 +366,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");   
 
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/linear-algebra/solvers/lu/lu.c
+++ b/OpenCL/linear-algebra/solvers/lu/lu.c
@@ -21,8 +21,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "lu.h"
 #include <polybench.h>
@@ -56,7 +54,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_2D(A_cpu,N,N,n,n), DATA_TYPE POLYBENCH_2D(A_outputFromGpu,N,N,n,n))
@@ -310,7 +307,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, a_mem_obj, CL_TRUE, 0, N*N*sizeof(DATA_TYPE), POLYBENCH_ARRAY(A_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 	
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 	
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/stencils/adi/adi.c
+++ b/OpenCL/stencils/adi/adi.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "adi.h"
 #include <polybench.h>
@@ -68,7 +66,6 @@ unsigned int mem_size_A;
 unsigned int mem_size_B;
 unsigned int mem_size_X;
 
-#define RUN_ON_CPU
 
 
 void init_array(int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(B,N,N,n,n), DATA_TYPE POLYBENCH_2D(X,N,N,n,n))
@@ -480,7 +477,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, x_mem_obj, CL_TRUE, 0, mem_size_X, POLYBENCH_ARRAY(X_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 	
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 	
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/stencils/convolution-2d/2DConvolution.c
+++ b/OpenCL/stencils/convolution-2d/2DConvolution.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "2DConvolution.h"
 #include <polybench.h>
@@ -59,7 +57,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int ni, int nj, DATA_TYPE POLYBENCH_2D(B, NI, NJ, ni, nj), DATA_TYPE POLYBENCH_2D(B_outputFromGpu, NI, NJ, ni, nj))
@@ -282,7 +279,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, b_mem_obj, CL_TRUE, 0, NI*NJ*sizeof(DATA_TYPE), POLYBENCH_ARRAY(B_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
   		polybench_start_instruments;

--- a/OpenCL/stencils/convolution-3d/3DConvolution.c
+++ b/OpenCL/stencils/convolution-3d/3DConvolution.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "3DConvolution.h"
 #include <polybench.h>
@@ -57,7 +55,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void read_cl_file()
@@ -304,7 +301,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, b_mem_obj, CL_TRUE, 0, NI * NJ * NK * sizeof(DATA_TYPE), POLYBENCH_ARRAY(B_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/stencils/fdtd-2d/fdtd2d.c
+++ b/OpenCL/stencils/fdtd-2d/fdtd2d.c
@@ -22,8 +22,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "fdtd2d.h"
 #include <polybench.h>
@@ -63,7 +61,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int nx, int ny, DATA_TYPE POLYBENCH_2D(hz1,NX,NY,nx,ny), DATA_TYPE POLYBENCH_2D(hz2,NX,NY,nx,ny))
@@ -362,7 +359,7 @@ int main(int argc, char *argv[])
 	errcode = clEnqueueReadBuffer(clCommandQue, hz_mem_obj, CL_TRUE, 0, NX * NY * sizeof(DATA_TYPE), POLYBENCH_ARRAY(hz_outputFromGpu), 0, NULL, NULL);
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");	
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/stencils/jacobi-1d-imper/jacobi1D.c
+++ b/OpenCL/stencils/jacobi-1d-imper/jacobi1D.c
@@ -21,8 +21,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "jacobi1D.h"
 #include <polybench.h>
@@ -57,7 +55,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_1D(a,N,n), DATA_TYPE POLYBENCH_1D(a_outFromGpu,N,n), DATA_TYPE POLYBENCH_1D(b,N,n), 
@@ -306,7 +303,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 		
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/stencils/jacobi-2d-imper/jacobi2D.c
+++ b/OpenCL/stencils/jacobi-2d-imper/jacobi2D.c
@@ -15,8 +15,6 @@
 
 #define POLYBENCH_TIME 1
 
-//select the OpenCL device to use (can be GPU, CPU, or Accelerator such as Intel Xeon Phi)
-#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
 
 #include "jacobi2D.h"
 #include <polybench.h>
@@ -58,7 +56,6 @@ FILE *fp;
 char *source_str;
 size_t source_size;
 
-#define RUN_ON_CPU
 
 
 void compareResults(int n, DATA_TYPE POLYBENCH_2D(a,N,N,n,n), DATA_TYPE POLYBENCH_2D(a_outputFromGpu,N,N,n,n), DATA_TYPE POLYBENCH_2D(b,N,N,n,n), DATA_TYPE POLYBENCH_2D(b_outputFromGpu,N,N,n,n))
@@ -344,7 +341,7 @@ int main(int argc, char *argv[])
 	if(errcode != CL_SUCCESS) printf("Error in reading GPU mem\n");
 
 
-	#ifdef RUN_ON_CPU
+	#if RUN_ON_CPU
 		
 		/* Start timer. */
 	  	polybench_start_instruments;

--- a/OpenCL/utilities/config.h
+++ b/OpenCL/utilities/config.h
@@ -1,0 +1,12 @@
+#ifndef POLYBENCH_ACC_CONFIG_H
+#define POLYBENCH_ACC_CONFIG_H
+
+#ifndef OPENCL_DEVICE_SELECTION
+#define OPENCL_DEVICE_SELECTION CL_DEVICE_TYPE_GPU
+#endif
+
+#ifndef RUN_ON_CPU
+#define RUN_ON_CPU (1)
+#endif
+
+#endif

--- a/OpenCL/utilities/polybench.h
+++ b/OpenCL/utilities/polybench.h
@@ -24,6 +24,10 @@
 # define POLYBENCH_H
 
 # include <stdlib.h>
+# include <string.h>
+# include <math.h>
+
+# include "config.h"
 
 /* Array padding. By default, none is used. */
 # ifndef POLYBENCH_PADDING_FACTOR


### PR DESCRIPTION
This patch introduces a new config.h file which conditionally defines
OPENCL_DEVICE_SELECTION and RUN_ON_CPU if they have not been passed on
the command line. This makes them optionally configurable by the build system.

If the build system does nothing different, this patch is NFC