### PR TITLE
OpenCL doitgen device

### DIFF
--- a/OpenCL/linear-algebra/kernels/doitgen/doitgen.c
+++ b/OpenCL/linear-algebra/kernels/doitgen/doitgen.c
@@ -167,7 +167,7 @@ void cl_initialization()
 	errcode = clGetPlatformInfo(platform_id, CL_PLATFORM_VERSION, sizeof(str_temp), str_temp,NULL);
 	if(errcode == CL_SUCCESS) printf("platform version is %s\n",str_temp);
 
-	errcode = clGetDeviceIDs( platform_id, CL_DEVICE_TYPE_GPU, 1, &device_id, &num_devices);
+	errcode = clGetDeviceIDs( platform_id, OPENCL_DEVICE_SELECTION, 1, &device_id, &num_devices);
 	if(errcode == CL_SUCCESS) printf("device id is %d\n",device_id);
 
 	errcode = clGetDeviceInfo(device_id,CL_DEVICE_NAME, sizeof(str_temp), str_temp,NULL);


### PR DESCRIPTION
[OpenCL] doitgen did not use the configured device
    
All other OpenCL test use `OPENCL_DEVICE_SELECTION`. This means
doitgen tries to use an incorrect or missing device if the configuration is
not `CL_DEVICE_TYPE_GPU`