### PR TITLE
fixed memory leaks and bugs in opencl

### DIFF
--- a/OpenCL/datamining/covariance/covariance.c
+++ b/OpenCL/datamining/covariance/covariance.c
@@ -267,13 +267,13 @@ void cl_clean_up()
 	errcode = clFinish(clCommandQue);
 	errcode = clReleaseKernel(clKernel_reduce);
 	errcode = clReleaseKernel(clKernel_mean);
-	errcode = clReleaseKernel(clKernel_std);
+	//errcode = clReleaseKernel(clKernel_std);
 	errcode = clReleaseKernel(clKernel_covar);
 	errcode = clReleaseProgram(clProgram);
 	errcode = clReleaseMemObject(symmat_mem_obj);
 	errcode = clReleaseMemObject(data_mem_obj);
 	errcode = clReleaseMemObject(mean_mem_obj);
-	errcode = clReleaseMemObject(stddev_mem_obj);
+	//errcode = clReleaseMemObject(stddev_mem_obj);
 	errcode = clReleaseCommandQueue(clCommandQue);
 	errcode = clReleaseContext(clGPUContext);
 	if(errcode != CL_SUCCESS) printf("Error in cleanup\n");

--- a/OpenCL/linear-algebra/kernels/gemver/gemver.c
+++ b/OpenCL/linear-algebra/kernels/gemver/gemver.c
@@ -298,6 +298,8 @@ void cl_clean_up()
 	errcode = clFlush(clCommandQue);
 	errcode = clFinish(clCommandQue);
 	errcode = clReleaseKernel(clKernel1);
+	errcode = clReleaseKernel(clKernel2);
+	errcode = clReleaseKernel(clKernel3);
 	errcode = clReleaseProgram(clProgram);
 	errcode = clReleaseMemObject(a_mem_obj);
 	errcode = clReleaseMemObject(u1_mem_obj);

--- a/OpenCL/linear-algebra/kernels/gesummv/gesummv.c
+++ b/OpenCL/linear-algebra/kernels/gesummv/gesummv.c
@@ -253,6 +253,8 @@ void cl_clean_up()
 	errcode = clReleaseMemObject(a_mem_obj);
 	errcode = clReleaseMemObject(b_mem_obj);
 	errcode = clReleaseMemObject(x_mem_obj);
+	errcode = clReleaseMemObject(y_mem_obj);
+	errcode = clReleaseMemObject(tmp_mem_obj);
 	errcode = clReleaseCommandQueue(clCommandQue);
 	errcode = clReleaseContext(clGPUContext);
 	if(errcode != CL_SUCCESS) printf("Error in cleanup\n");

--- a/OpenCL/linear-algebra/kernels/syr2k/syr2k.c
+++ b/OpenCL/linear-algebra/kernels/syr2k/syr2k.c
@@ -241,6 +241,7 @@ void cl_clean_up()
 	errcode = clReleaseKernel(clKernel1);
 	errcode = clReleaseProgram(clProgram);
 	errcode = clReleaseMemObject(a_mem_obj);
+	errcode = clReleaseMemObject(b_mem_obj);
 	errcode = clReleaseMemObject(c_mem_obj);
 	errcode = clReleaseCommandQueue(clCommandQue);
 	errcode = clReleaseContext(clGPUContext);


### PR DESCRIPTION
The clKernel_std and stddev_mem_obj in covariance are never created and therefore can not be freed.
In gemver, gesummv and syr2k were some frees missing.