### PR TITLE
[CUDA] Replace deprecated `cudaThreadSynchronize` with `cudaDeviceSynchronize`

### DIFF
--- a/CUDA/datamining/correlation/correlation.cu
+++ b/CUDA/datamining/correlation/correlation.cu
@@ -15,7 +15,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "correlation.cuh"
 #include <polybench.h>
@@ -31,7 +30,6 @@
 #define FLOAT_N 3214212.01f
 #define EPS 0.005f
 
-#define RUN_ON_CPU
 
 
 void init_arrays(int m, int n, DATA_TYPE POLYBENCH_2D(data, M, N, m, n))

--- a/CUDA/datamining/correlation/correlation.cu
+++ b/CUDA/datamining/correlation/correlation.cu
@@ -255,13 +255,13 @@ void correlationCuda(int m, int n, DATA_TYPE POLYBENCH_2D(data, M, N, m, n), DAT
   	polybench_start_instruments;
 
 	mean_kernel<<< grid1, block1 >>>(m, n, mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	std_kernel<<< grid2, block2 >>>(m, n, mean_gpu,stddev_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	reduce_kernel<<< grid3, block3 >>>(m, n, mean_gpu,stddev_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	corr_kernel<<< grid4, block4 >>>(m, n, symmat_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/datamining/covariance/covariance.cu
+++ b/CUDA/datamining/covariance/covariance.cu
@@ -196,11 +196,11 @@ void covarianceCuda(int m, int n, DATA_TYPE POLYBENCH_2D(data,M,N,m,n), DATA_TYP
   	polybench_start_instruments;
 
 	mean_kernel<<<grid1, block1>>>(m,n,mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	reduce_kernel<<<grid2, block2>>>(m,n,mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	covar_kernel<<<grid3, block3>>>(m,n,symmat_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/datamining/covariance/covariance.cu
+++ b/CUDA/datamining/covariance/covariance.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "covariance.cuh"
 #include <polybench.h>
@@ -32,7 +31,6 @@
 #define FLOAT_N 3214212.01
 #define EPS 0.005
 
-#define RUN_ON_CPU
 
 
 void init_arrays(int m, int n, DATA_TYPE POLYBENCH_2D(data,M,N,m,n))

--- a/CUDA/linear-algebra/kernels/2mm/2mm.cu
+++ b/CUDA/linear-algebra/kernels/2mm/2mm.cu
@@ -222,9 +222,9 @@ void mm2Cuda(int ni, int nj, int nk, int nl, DATA_TYPE alpha, DATA_TYPE beta, DA
   	polybench_start_instruments;
 
 	mm2_kernel1<<<grid1,block>>>(ni, nj, nk, nl, alpha, beta, tmp_gpu, A_gpu, B_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm2_kernel2<<<grid2,block>>>(ni, nj, nk, nl, alpha, beta, tmp_gpu, C_gpu, D_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;

--- a/CUDA/linear-algebra/kernels/2mm/2mm.cu
+++ b/CUDA/linear-algebra/kernels/2mm/2mm.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "2mm.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void init_array(int ni, int nj, int nk, int nl, DATA_TYPE *alpha, DATA_TYPE *beta, DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk), 

--- a/CUDA/linear-algebra/kernels/3mm/3mm.cu
+++ b/CUDA/linear-algebra/kernels/3mm/3mm.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "3mm.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 //define the error threshold for the results "not matching"
 #define PERCENT_DIFF_ERROR_THRESHOLD 0.05
 
-#define RUN_ON_CPU
 
 
 void init_array(int ni, int nj, int nk, int nl, int nm, DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk), DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj), 

--- a/CUDA/linear-algebra/kernels/3mm/3mm.cu
+++ b/CUDA/linear-algebra/kernels/3mm/3mm.cu
@@ -246,11 +246,11 @@ void mm3Cuda(int ni, int nj, int nk, int nl, int nm,
   	polybench_start_instruments;
 
 	mm3_kernel1<<<grid1,block>>>(ni, nj, nk, nl, nm, A_gpu, B_gpu, E_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm3_kernel2<<<grid2,block>>>(ni, nj, nk, nl, nm, C_gpu, D_gpu, F_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm3_kernel3<<<grid3,block>>>(ni, nj, nk, nl, nm, E_gpu, F_gpu, G_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/atax/atax.cu
+++ b/CUDA/linear-algebra/kernels/atax/atax.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "atax.cuh"
 #include <polybench.h>
@@ -32,7 +31,6 @@
 #define M_PI 3.14159
 #endif
 
-#define RUN_ON_CPU
 
 
 void init_array(int nx, int ny, DATA_TYPE POLYBENCH_1D(x,NX,nx), DATA_TYPE POLYBENCH_2D(A,NX,NY,nx,ny))

--- a/CUDA/linear-algebra/kernels/atax/atax.cu
+++ b/CUDA/linear-algebra/kernels/atax/atax.cu
@@ -161,9 +161,9 @@ void ataxGpu(int nx, int ny, DATA_TYPE POLYBENCH_2D(A, NX, NY,nx,ny), DATA_TYPE 
   	polybench_start_instruments;
 
 	atax_kernel1<<< grid1, block >>>(nx, ny, A_gpu,x_gpu,tmp_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	atax_kernel2<<< grid2, block >>>(nx, ny, A_gpu,y_gpu,tmp_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/bicg/bicg.cu
+++ b/CUDA/linear-algebra/kernels/bicg/bicg.cu
@@ -200,9 +200,9 @@ void bicgCuda(int nx, int ny, DATA_TYPE POLYBENCH_2D(A,NX,NY,nx,ny), DATA_TYPE P
   	polybench_start_instruments;
 
 	bicg_kernel1<<< grid1, block >>>(nx, ny, A_gpu, r_gpu, s_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	bicg_kernel2<<< grid2, block >>>(nx, ny, A_gpu, p_gpu, q_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/bicg/bicg.cu
+++ b/CUDA/linear-algebra/kernels/bicg/bicg.cu
@@ -15,7 +15,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "bicg.cuh"
 #include <polybench.h>
@@ -30,7 +29,6 @@
 #define M_PI 3.14159
 #endif
 
-#define RUN_ON_CPU
 
 
 void init_array(int nx, int ny, DATA_TYPE POLYBENCH_2D(A,NX,NY,nx,ny), DATA_TYPE POLYBENCH_1D(p,NY,ny), DATA_TYPE POLYBENCH_1D(r,NX,nx))

--- a/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
+++ b/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "doitgen.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 

--- a/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
+++ b/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
@@ -164,9 +164,9 @@ void doitgenCuda(int nr, int nq, int np,
 	for (int r = 0; r < nr; r++)
 	{
 		doitgen_kernel1 <<<grid, block>>> (nr, nq, np, sumGpu, AGpu, C4Gpu, r);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		doitgen_kernel2 <<<grid, block>>> (nr, nq, np, sumGpu, AGpu, C4Gpu, r);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/linear-algebra/kernels/gemm/gemm.cu
+++ b/CUDA/linear-algebra/kernels/gemm/gemm.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "gemm.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 //define the error threshold for the results "not matching"
 #define PERCENT_DIFF_ERROR_THRESHOLD 0.05
 
-#define RUN_ON_CPU
 
 
 void gemm(int ni, int nj, int nk, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBENCH_2D(A,NI,NK,ni,nk), 

--- a/CUDA/linear-algebra/kernels/gemm/gemm.cu
+++ b/CUDA/linear-algebra/kernels/gemm/gemm.cu
@@ -155,7 +155,7 @@ void gemmCuda(int ni, int nj, int nk, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE
   	polybench_start_instruments;
 
 	gemm_kernel<<< grid, block >>>(ni, nj, nk, alpha, beta, A_gpu, B_gpu, C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/gemver/gemver.cu
+++ b/CUDA/linear-algebra/kernels/gemver/gemver.cu
@@ -229,11 +229,11 @@ void gemverCuda(int n, DATA_TYPE alpha, DATA_TYPE beta,
   	polybench_start_instruments;
 
 	gemver_kernel1<<< grid1, block1 >>>(n, alpha, beta, A_gpu,v1_gpu,v2_gpu, u1_gpu, u2_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	gemver_kernel2<<< grid2, block2 >>>(n, alpha, beta, A_gpu,x_gpu,y_gpu, z_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	gemver_kernel3<<< grid3, block3 >>>(n, alpha, beta, A_gpu,x_gpu,w_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/gemver/gemver.cu
+++ b/CUDA/linear-algebra/kernels/gemver/gemver.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "gemver.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void gemver(int n, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBENCH_2D(A, N, N, n, n), DATA_TYPE POLYBENCH_1D(u1, N, n), DATA_TYPE POLYBENCH_1D(v1, N, n), 

--- a/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
+++ b/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "gesummv.cuh"
 #include <polybench.h>
@@ -32,7 +31,6 @@
 #define ALPHA 43532.0f
 #define BETA 12313.0f
 
-#define RUN_ON_CPU
 
 
 void gesummv(int n, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(B,N,N,n,n), DATA_TYPE POLYBENCH_1D(tmp,N,n),

--- a/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
+++ b/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
@@ -149,7 +149,7 @@ void gesummvCuda(int n, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBENCH_2D(
   	polybench_start_instruments;
 
 	gesummv_kernel<<< grid, block>>>(n, alpha, beta, A_gpu, B_gpu, tmp_gpu, x_gpu, y_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/mvt/mvt.cu
+++ b/CUDA/linear-algebra/kernels/mvt/mvt.cu
@@ -160,7 +160,7 @@ void mvtCuda(int n, DATA_TYPE POLYBENCH_2D(a, N, N, n, n), DATA_TYPE POLYBENCH_1
 	
 	mvt_kernel1<<<grid,block>>>(n, a_gpu,x1_gpu,y_1_gpu);
 	mvt_kernel2<<<grid,block>>>(n, a_gpu,x2_gpu,y_2_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/mvt/mvt.cu
+++ b/CUDA/linear-algebra/kernels/mvt/mvt.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "mvt.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void init_array(int n, DATA_TYPE POLYBENCH_2D(A, N, N, n, n), DATA_TYPE POLYBENCH_1D(x1, N, n), DATA_TYPE POLYBENCH_1D(x2, N, n), DATA_TYPE POLYBENCH_1D(y1, N, n), DATA_TYPE POLYBENCH_1D(y2, N, n))

--- a/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
+++ b/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "syr2k.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void init_arrays(int ni, int nj,

--- a/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
+++ b/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
@@ -163,7 +163,7 @@ void syr2kCuda(int ni, int nj, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBE
   	polybench_start_instruments;
 
 	syr2k_kernel<<<grid,block>>>(ni, nj, alpha, beta, A_gpu, B_gpu, C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/syrk/syrk.cu
+++ b/CUDA/linear-algebra/kernels/syrk/syrk.cu
@@ -153,7 +153,7 @@ void syrkCuda(int ni, int nj, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBEN
   	polybench_start_instruments;
 
 	syrk_kernel<<<grid,block>>>(ni, nj, alpha, beta, A_gpu,C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/syrk/syrk.cu
+++ b/CUDA/linear-algebra/kernels/syrk/syrk.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "syrk.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void init_arrays(int ni, int nj,

--- a/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
+++ b/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
@@ -193,11 +193,11 @@ void gramschmidtCuda(int ni, int nj, DATA_TYPE POLYBENCH_2D(A,NI,NJ,ni,nj), DATA
 	for (k = 0; k < _PB_NJ; k++)
 	{
 		gramschmidt_kernel1<<<gridKernel1,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		gramschmidt_kernel2<<<gridKernel2,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		gramschmidt_kernel3<<<gridKernel3,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;

--- a/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
+++ b/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "gramschmidt.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void gramschmidt(int ni, int nj, DATA_TYPE POLYBENCH_2D(A,NI,NJ,ni,nj), DATA_TYPE POLYBENCH_2D(R,NJ,NJ,nj,nj), DATA_TYPE POLYBENCH_2D(Q,NI,NJ,ni,nj))

--- a/CUDA/linear-algebra/solvers/lu/lu.cu
+++ b/CUDA/linear-algebra/solvers/lu/lu.cu
@@ -16,7 +16,6 @@
 #include <stdarg.h>
 #include <string.h>
 
-#define POLYBENCH_TIME 1
 
 #include "lu.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void lu(int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n))

--- a/CUDA/linear-algebra/solvers/lu/lu.cu
+++ b/CUDA/linear-algebra/solvers/lu/lu.cu
@@ -137,12 +137,12 @@ void luCuda(int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(A_o
 	{
 		grid1.x = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block1.x)));
 		lu_kernel1<<<grid1, block1>>>(n, AGpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 
 		grid2.x = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block2.x)));
 		grid2.y = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block2.y)));
 		lu_kernel2<<<grid2, block2>>>(n, AGpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	
 	/* Stop and print timer. */

--- a/CUDA/stencils/adi/adi.cu
+++ b/CUDA/stencils/adi/adi.cu
@@ -16,7 +16,6 @@
 #include <stdarg.h>
 #include <string.h>
 
-#define POLYBENCH_TIME 1
 
 #include "adi.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void adi(int tsteps, int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(B,N,N,n,n), DATA_TYPE POLYBENCH_2D(X,N,N,n,n))

--- a/CUDA/stencils/adi/adi.cu
+++ b/CUDA/stencils/adi/adi.cu
@@ -239,25 +239,25 @@ void adiCuda(int tsteps, int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POL
 	{
 		
 		adi_kernel1<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		adi_kernel2<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		adi_kernel3<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	
 		for (int i1 = 1; i1 < _PB_N; i1++)
 		{
 			adi_kernel4<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu, i1);
-			cudaThreadSynchronize();
+			cudaDeviceSynchronize();
 		}
 
 		adi_kernel5<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		
 		for (int i1 = 0; i1 < _PB_N-2; i1++)
 		{
 			adi_kernel6<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu, i1);
-			cudaThreadSynchronize();
+			cudaDeviceSynchronize();
 		}
 	}
 

--- a/CUDA/stencils/convolution-2d/2DConvolution.cu
+++ b/CUDA/stencils/convolution-2d/2DConvolution.cu
@@ -136,7 +136,7 @@ void convolution2DCuda(int ni, int nj, DATA_TYPE POLYBENCH_2D(A, NI, NJ, ni, nj)
   	polybench_start_instruments;
 
 	convolution2D_kernel <<< grid,block >>> (ni, nj, A_gpu,B_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/stencils/convolution-2d/2DConvolution.cu
+++ b/CUDA/stencils/convolution-2d/2DConvolution.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "2DConvolution.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void conv2D(int ni, int nj, DATA_TYPE POLYBENCH_2D(A, NI, NJ, ni, nj), DATA_TYPE POLYBENCH_2D(B, NI, NJ, ni, nj))

--- a/CUDA/stencils/convolution-3d/3DConvolution.cu
+++ b/CUDA/stencils/convolution-3d/3DConvolution.cu
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "3DConvolution.cuh"
 #include <polybench.h>
@@ -28,7 +27,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void conv3D(int ni, int nj, int nk, DATA_TYPE POLYBENCH_3D(A, NI, NJ, NK, ni, nj, nk), DATA_TYPE POLYBENCH_3D(B, NI, NJ, NK, ni, nj, nk))

--- a/CUDA/stencils/convolution-3d/3DConvolution.cu
+++ b/CUDA/stencils/convolution-3d/3DConvolution.cu
@@ -159,7 +159,7 @@ void convolution3DCuda(int ni, int nj, int nk, DATA_TYPE POLYBENCH_3D(A, NI, NJ,
 		convolution3D_kernel<<< grid, block >>>(ni, nj, nk, A_gpu, B_gpu, i);
 	}
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;
  	polybench_print_instruments;

--- a/CUDA/stencils/fdtd-2d/fdtd2d.cu
+++ b/CUDA/stencils/fdtd-2d/fdtd2d.cu
@@ -16,7 +16,6 @@
 #include <sys/time.h>
 #include <cuda.h>
 
-#define POLYBENCH_TIME 1
 
 #include "fdtd2d.cuh"
 #include <polybench.h>
@@ -27,7 +26,6 @@
 
 #define GPU_DEVICE 0
 
-#define RUN_ON_CPU
 
 
 void init_arrays(int tmax, int nx, int ny, DATA_TYPE POLYBENCH_1D(_fict_, TMAX, TMAX), DATA_TYPE POLYBENCH_2D(ex,NX,NY,nx,ny), 

--- a/CUDA/stencils/fdtd-2d/fdtd2d.cu
+++ b/CUDA/stencils/fdtd-2d/fdtd2d.cu
@@ -193,11 +193,11 @@ void fdtdCuda(int tmax, int nx, int ny, DATA_TYPE POLYBENCH_1D(_fict_, TMAX, TMA
 	for(int t = 0; t < _PB_TMAX; t++)
 	{
 		fdtd_step1_kernel<<<grid,block>>>(nx, ny, _fict_gpu, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		fdtd_step2_kernel<<<grid,block>>>(nx, ny, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		fdtd_step3_kernel<<<grid,block>>>(nx, ny, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	
 	/* Stop and print timer. */

--- a/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
+++ b/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
@@ -129,9 +129,9 @@ void runJacobi1DCUDA(int tsteps, int n, DATA_TYPE POLYBENCH_1D(A,N,n), DATA_TYPE
 	for (int t = 0; t < _PB_TSTEPS ; t++)
 	{
 		runJacobiCUDA_kernel1 <<< grid, block >>> (n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		runJacobiCUDA_kernel2 <<< grid, block>>> (n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
+++ b/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
@@ -17,7 +17,6 @@
 #include <stdarg.h>
 #include <math.h>
 
-#define POLYBENCH_TIME 1
 
 #include "jacobi1D.cuh"
 #include <polybench.h>
@@ -26,7 +25,6 @@
 //define the error threshold for the results "not matching"
 #define PERCENT_DIFF_ERROR_THRESHOLD 0.05
 
-#define RUN_ON_CPU
 
 
 void init_array(int n, DATA_TYPE POLYBENCH_1D(A,N,n), DATA_TYPE POLYBENCH_1D(B,N,n))

--- a/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
+++ b/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
@@ -17,7 +17,6 @@
 #include <stdarg.h>
 #include <math.h>
 
-#define POLYBENCH_TIME 1
 
 #include "jacobi2D.cuh"
 #include <polybench.h>
@@ -26,7 +25,6 @@
 //define the error threshold for the results "not matching"
 #define PERCENT_DIFF_ERROR_THRESHOLD 0.05
 
-#define RUN_ON_CPU
 
 
 void init_array(int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(B,N,N,n,n))

--- a/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
+++ b/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
@@ -143,9 +143,9 @@ void runJacobi2DCUDA(int tsteps, int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_
 	for (int t = 0; t < _PB_TSTEPS; t++)
 	{
 		runJacobiCUDA_kernel1<<<grid,block>>>(n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		runJacobiCUDA_kernel2<<<grid,block>>>(n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/utilities/common.mk
+++ b/CUDA/utilities/common.mk
@@ -1,4 +1,6 @@
+NVCC = nvcc
+
 all:
-	nvcc -O3 ${CUFILES} -I${PATH_TO_UTILS} -o ${EXECUTABLE} 
+	${NVCC} -O3 ${CUFILES} -I${PATH_TO_UTILS} -o ${EXECUTABLE} 
 clean:
 	rm -f *~ *.exe


### PR DESCRIPTION
## What's the Problem?

`cudaThreadSynchronize` is deprecated since its name does not reflect its behavior [^1].

## What's Changed?

The non-deprecated counterpart `cudaDeviceSynchronize` is now used instead.

## How is it Tested?

I've compiled the affected files with `make -B`. All of them can be compiled successfully without warnings about deprecation.

Here's the version of `nvcc`:

```
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Tue_Oct_29_23:50:19_PDT_2024
Cuda compilation tools, release 12.6, V12.6.85
Build cuda_12.6.r12.6/compiler.35059454_0
```

Resolved: #15

[^1]: [CUDA Runtime API, 6.3. Thread Management [DEPRECATED]](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__THREAD__DEPRECATED.html#group__CUDART__THREAD__DEPRECATED_1g86ba4d3d51221f18a9a13663e6105fc1)