### PR TITLE
Make DATASET selection configurable via macro concatenation (-D`<DATASET>`_DATASET)

### DIFF
--- a/CUDA/datamining/correlation/Makefile
+++ b/CUDA/datamining/correlation/Makefile
@@ -1,5 +1,6 @@
 EXECUTABLE := correlation.exe
 CUFILES := correlation.cu
+LDFLAGS := -lm
 PATH_TO_UTILS := ../../utilities
 
 include ${PATH_TO_UTILS}/common.mk

--- a/CUDA/datamining/correlation/correlation.cu
+++ b/CUDA/datamining/correlation/correlation.cu
@@ -255,13 +255,13 @@ void correlationCuda(int m, int n, DATA_TYPE POLYBENCH_2D(data, M, N, m, n), DAT
   	polybench_start_instruments;
 
 	mean_kernel<<< grid1, block1 >>>(m, n, mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	std_kernel<<< grid2, block2 >>>(m, n, mean_gpu,stddev_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	reduce_kernel<<< grid3, block3 >>>(m, n, mean_gpu,stddev_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	corr_kernel<<< grid4, block4 >>>(m, n, symmat_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/datamining/covariance/covariance.cu
+++ b/CUDA/datamining/covariance/covariance.cu
@@ -196,11 +196,11 @@ void covarianceCuda(int m, int n, DATA_TYPE POLYBENCH_2D(data,M,N,m,n), DATA_TYP
   	polybench_start_instruments;
 
 	mean_kernel<<<grid1, block1>>>(m,n,mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	reduce_kernel<<<grid2, block2>>>(m,n,mean_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	covar_kernel<<<grid3, block3>>>(m,n,symmat_gpu,data_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/2mm/2mm.cu
+++ b/CUDA/linear-algebra/kernels/2mm/2mm.cu
@@ -222,9 +222,9 @@ void mm2Cuda(int ni, int nj, int nk, int nl, DATA_TYPE alpha, DATA_TYPE beta, DA
   	polybench_start_instruments;
 
 	mm2_kernel1<<<grid1,block>>>(ni, nj, nk, nl, alpha, beta, tmp_gpu, A_gpu, B_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm2_kernel2<<<grid2,block>>>(ni, nj, nk, nl, alpha, beta, tmp_gpu, C_gpu, D_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;

--- a/CUDA/linear-algebra/kernels/3mm/3mm.cu
+++ b/CUDA/linear-algebra/kernels/3mm/3mm.cu
@@ -246,11 +246,11 @@ void mm3Cuda(int ni, int nj, int nk, int nl, int nm,
   	polybench_start_instruments;
 
 	mm3_kernel1<<<grid1,block>>>(ni, nj, nk, nl, nm, A_gpu, B_gpu, E_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm3_kernel2<<<grid2,block>>>(ni, nj, nk, nl, nm, C_gpu, D_gpu, F_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	mm3_kernel3<<<grid3,block>>>(ni, nj, nk, nl, nm, E_gpu, F_gpu, G_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/atax/atax.cu
+++ b/CUDA/linear-algebra/kernels/atax/atax.cu
@@ -161,9 +161,9 @@ void ataxGpu(int nx, int ny, DATA_TYPE POLYBENCH_2D(A, NX, NY,nx,ny), DATA_TYPE 
   	polybench_start_instruments;
 
 	atax_kernel1<<< grid1, block >>>(nx, ny, A_gpu,x_gpu,tmp_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	atax_kernel2<<< grid2, block >>>(nx, ny, A_gpu,y_gpu,tmp_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/bicg/bicg.cu
+++ b/CUDA/linear-algebra/kernels/bicg/bicg.cu
@@ -200,9 +200,9 @@ void bicgCuda(int nx, int ny, DATA_TYPE POLYBENCH_2D(A,NX,NY,nx,ny), DATA_TYPE P
   	polybench_start_instruments;
 
 	bicg_kernel1<<< grid1, block >>>(nx, ny, A_gpu, r_gpu, s_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	bicg_kernel2<<< grid2, block >>>(nx, ny, A_gpu, p_gpu, q_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
+++ b/CUDA/linear-algebra/kernels/doitgen/doitgen.cu
@@ -164,9 +164,9 @@ void doitgenCuda(int nr, int nq, int np,
 	for (int r = 0; r < nr; r++)
 	{
 		doitgen_kernel1 <<<grid, block>>> (nr, nq, np, sumGpu, AGpu, C4Gpu, r);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		doitgen_kernel2 <<<grid, block>>> (nr, nq, np, sumGpu, AGpu, C4Gpu, r);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/linear-algebra/kernels/gemm/gemm.cu
+++ b/CUDA/linear-algebra/kernels/gemm/gemm.cu
@@ -155,7 +155,7 @@ void gemmCuda(int ni, int nj, int nk, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE
   	polybench_start_instruments;
 
 	gemm_kernel<<< grid, block >>>(ni, nj, nk, alpha, beta, A_gpu, B_gpu, C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/gemver/gemver.cu
+++ b/CUDA/linear-algebra/kernels/gemver/gemver.cu
@@ -229,11 +229,11 @@ void gemverCuda(int n, DATA_TYPE alpha, DATA_TYPE beta,
   	polybench_start_instruments;
 
 	gemver_kernel1<<< grid1, block1 >>>(n, alpha, beta, A_gpu,v1_gpu,v2_gpu, u1_gpu, u2_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	gemver_kernel2<<< grid2, block2 >>>(n, alpha, beta, A_gpu,x_gpu,y_gpu, z_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	gemver_kernel3<<< grid3, block3 >>>(n, alpha, beta, A_gpu,x_gpu,w_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
+++ b/CUDA/linear-algebra/kernels/gesummv/gesummv.cu
@@ -149,7 +149,7 @@ void gesummvCuda(int n, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBENCH_2D(
   	polybench_start_instruments;
 
 	gesummv_kernel<<< grid, block>>>(n, alpha, beta, A_gpu, B_gpu, tmp_gpu, x_gpu, y_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/mvt/mvt.cu
+++ b/CUDA/linear-algebra/kernels/mvt/mvt.cu
@@ -160,7 +160,7 @@ void mvtCuda(int n, DATA_TYPE POLYBENCH_2D(a, N, N, n, n), DATA_TYPE POLYBENCH_1
 	
 	mvt_kernel1<<<grid,block>>>(n, a_gpu,x1_gpu,y_1_gpu);
 	mvt_kernel2<<<grid,block>>>(n, a_gpu,x2_gpu,y_2_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
+++ b/CUDA/linear-algebra/kernels/syr2k/syr2k.cu
@@ -163,7 +163,7 @@ void syr2kCuda(int ni, int nj, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBE
   	polybench_start_instruments;
 
 	syr2k_kernel<<<grid,block>>>(ni, nj, alpha, beta, A_gpu, B_gpu, C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/kernels/syrk/syrk.cu
+++ b/CUDA/linear-algebra/kernels/syrk/syrk.cu
@@ -153,7 +153,7 @@ void syrkCuda(int ni, int nj, DATA_TYPE alpha, DATA_TYPE beta, DATA_TYPE POLYBEN
   	polybench_start_instruments;
 
 	syrk_kernel<<<grid,block>>>(ni, nj, alpha, beta, A_gpu,C_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/linear-algebra/solvers/gramschmidt/Makefile
+++ b/CUDA/linear-algebra/solvers/gramschmidt/Makefile
@@ -1,5 +1,6 @@
 EXECUTABLE := gramschmidt.exe
 CUFILES := gramschmidt.cu
+LDFLAGS := -lm
 PATH_TO_UTILS := ../../../utilities
 
 include ${PATH_TO_UTILS}/common.mk

--- a/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
+++ b/CUDA/linear-algebra/solvers/gramschmidt/gramschmidt.cu
@@ -193,11 +193,11 @@ void gramschmidtCuda(int ni, int nj, DATA_TYPE POLYBENCH_2D(A,NI,NJ,ni,nj), DATA
 	for (k = 0; k < _PB_NJ; k++)
 	{
 		gramschmidt_kernel1<<<gridKernel1,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		gramschmidt_kernel2<<<gridKernel2,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		gramschmidt_kernel3<<<gridKernel3,block>>>(ni, nj, A_gpu, R_gpu, Q_gpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;

--- a/CUDA/linear-algebra/solvers/lu/lu.cu
+++ b/CUDA/linear-algebra/solvers/lu/lu.cu
@@ -137,12 +137,12 @@ void luCuda(int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POLYBENCH_2D(A_o
 	{
 		grid1.x = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block1.x)));
 		lu_kernel1<<<grid1, block1>>>(n, AGpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 
 		grid2.x = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block2.x)));
 		grid2.y = (unsigned int)(ceil((float)(N - (k + 1)) / ((float)block2.y)));
 		lu_kernel2<<<grid2, block2>>>(n, AGpu, k);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	
 	/* Stop and print timer. */

--- a/CUDA/stencils/adi/adi.cu
+++ b/CUDA/stencils/adi/adi.cu
@@ -239,25 +239,25 @@ void adiCuda(int tsteps, int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_TYPE POL
 	{
 		
 		adi_kernel1<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		adi_kernel2<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		adi_kernel3<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	
 		for (int i1 = 1; i1 < _PB_N; i1++)
 		{
 			adi_kernel4<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu, i1);
-			cudaThreadSynchronize();
+			cudaDeviceSynchronize();
 		}
 
 		adi_kernel5<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		
 		for (int i1 = 0; i1 < _PB_N-2; i1++)
 		{
 			adi_kernel6<<<grid1, block1>>>(n, A_gpu, B_gpu, X_gpu, i1);
-			cudaThreadSynchronize();
+			cudaDeviceSynchronize();
 		}
 	}
 

--- a/CUDA/stencils/convolution-2d/2DConvolution.cu
+++ b/CUDA/stencils/convolution-2d/2DConvolution.cu
@@ -136,7 +136,7 @@ void convolution2DCuda(int ni, int nj, DATA_TYPE POLYBENCH_2D(A, NI, NJ, ni, nj)
   	polybench_start_instruments;
 
 	convolution2D_kernel <<< grid,block >>> (ni, nj, A_gpu,B_gpu);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	
 	/* Stop and print timer. */
 	printf("GPU Time in seconds:\n");

--- a/CUDA/stencils/convolution-3d/3DConvolution.cu
+++ b/CUDA/stencils/convolution-3d/3DConvolution.cu
@@ -159,7 +159,7 @@ void convolution3DCuda(int ni, int nj, int nk, DATA_TYPE POLYBENCH_3D(A, NI, NJ,
 		convolution3D_kernel<<< grid, block >>>(ni, nj, nk, A_gpu, B_gpu, i);
 	}
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	printf("GPU Time in seconds:\n");
   	polybench_stop_instruments;
  	polybench_print_instruments;

--- a/CUDA/stencils/fdtd-2d/fdtd2d.cu
+++ b/CUDA/stencils/fdtd-2d/fdtd2d.cu
@@ -193,11 +193,11 @@ void fdtdCuda(int tmax, int nx, int ny, DATA_TYPE POLYBENCH_1D(_fict_, TMAX, TMA
 	for(int t = 0; t < _PB_TMAX; t++)
 	{
 		fdtd_step1_kernel<<<grid,block>>>(nx, ny, _fict_gpu, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		fdtd_step2_kernel<<<grid,block>>>(nx, ny, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		fdtd_step3_kernel<<<grid,block>>>(nx, ny, ex_gpu, ey_gpu, hz_gpu, t);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 	
 	/* Stop and print timer. */

--- a/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
+++ b/CUDA/stencils/jacobi-1d-imper/jacobi1D.cu
@@ -129,9 +129,9 @@ void runJacobi1DCUDA(int tsteps, int n, DATA_TYPE POLYBENCH_1D(A,N,n), DATA_TYPE
 	for (int t = 0; t < _PB_TSTEPS ; t++)
 	{
 		runJacobiCUDA_kernel1 <<< grid, block >>> (n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		runJacobiCUDA_kernel2 <<< grid, block>>> (n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
+++ b/CUDA/stencils/jacobi-2d-imper/jacobi2D.cu
@@ -143,9 +143,9 @@ void runJacobi2DCUDA(int tsteps, int n, DATA_TYPE POLYBENCH_2D(A,N,N,n,n), DATA_
 	for (int t = 0; t < _PB_TSTEPS; t++)
 	{
 		runJacobiCUDA_kernel1<<<grid,block>>>(n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 		runJacobiCUDA_kernel2<<<grid,block>>>(n, Agpu, Bgpu);
-		cudaThreadSynchronize();
+		cudaDeviceSynchronize();
 	}
 
 	/* Stop and print timer. */

--- a/CUDA/utilities/common.mk
+++ b/CUDA/utilities/common.mk
@@ -1,4 +1,7 @@
+DATASET ?= STANDARD
+DATASET_MACRO := $(DATASET)_DATASET
+
 all:
-	nvcc -O3 ${CUFILES} -I${PATH_TO_UTILS} -o ${EXECUTABLE} 
+	nvcc -O3 ${CUFILES} ${LDFLAGS} -D${DATASET_MACRO} -I${PATH_TO_UTILS} -o ${EXECUTABLE} 
 clean:
 	rm -f *~ *.exe

--- a/HMPP/utilities/common.mk
+++ b/HMPP/utilities/common.mk
@@ -10,6 +10,9 @@ SRC += $(UTIL_DIR)/polybench.c
 DEPS        := Makefile.dep
 DEP_FLAG    := -MM
 
+DATASET ?= STANDARD
+DATASET_MACRO := $(DATASET)_DATASET
+
 .PHONY: all exe clean veryclean
 
 all : exe
@@ -17,7 +20,7 @@ all : exe
 exe : $(EXE)
 
 $(EXE) : $(SRC)
-	$(HMPP) $(HMPPFLAGS) $(CC) $(CFLAGS) $(INCPATHS) $^ -o $@
+	$(HMPP) $(HMPPFLAGS) $(CC) $(CFLAGS) $(INCPATHS) -D${DATASET_MACRO} $^ -o $@
 
 clean :
 	-rm -vf *.hmc* -vf $(EXE) *~ 
@@ -26,6 +29,6 @@ veryclean : clean
 	-rm -vf $(DEPS)
 
 $(DEPS): $(SRC) $(HEADERS)
-	$(CC) $(INCPATHS) $(DEP_FLAG) $(SRC) > $(DEPS)
+	$(CC) $(INCPATHS) $(DEP_FLAG) -D${DATASET_MACRO} $(SRC) > $(DEPS)
 
 -include $(DEPS)

--- a/OpenACC/utilities/common.mk
+++ b/OpenACC/utilities/common.mk
@@ -9,6 +9,9 @@ HEADERS = $(BENCHMARK).h
 DEPS        := Makefile.dep
 DEP_FLAG    := -MM
 
+DATASET ?= STANDARD
+DATASET_MACRO := $(DATASET)_DATASET
+
 .PHONY: all exe clean veryclean
 
 all : exe
@@ -19,7 +22,7 @@ $(OBJ) : $(SRC)
 	$(ACC) $(ACCFLAGS) $(ACC_INC_PATH) $(INCPATHS) $^
 
 $(EXE) : $(OBJ) $(BENCHMARK)-data.c $(UTIL_DIR)/polybench.c
-	$(CC) -o $@ $(CFLAGS) $(ACC_INC_PATH) $(ACC_LIB_PATH) $(INCPATHS) $^ $(ACC_LIBS)
+	$(CC) -o $@ $(CFLAGS) $(ACC_INC_PATH) $(ACC_LIB_PATH) $(INCPATHS) -D${DATASET_MACRO} $^ $(ACC_LIBS)
 
 check: exe
 	./$(EXE)
@@ -32,6 +35,6 @@ veryclean : clean
 	-rm -vf $(DEPS)
 
 $(DEPS): $(SRC) $(HEADERS)
-	$(CC) $(INCPATHS) $(DEP_FLAG) $(SRC) > $(DEPS)
+	$(CC) $(INCPATHS) $(DEP_FLAG) -D${DATASET_MACRO} $(SRC) > $(DEPS)
 
 -include $(DEPS)

--- a/OpenCL/utilities/common.mk
+++ b/OpenCL/utilities/common.mk
@@ -2,8 +2,12 @@ OpenCL_SDK=/global/homes/s/sgrauerg/NVIDIA_GPU_Computing_SDK
 INCLUDE=-I${OpenCL_SDK}/OpenCL/common/inc -I${PATH_TO_UTILS}
 LIBPATH=-L${OpenCL_SDK}/OpenCL/common/lib -L${OpenCL_SDK}/shared/lib
 LIB=-lOpenCL -lm
+
+DATASET ?= STANDARD
+DATASET_MACRO := $(DATASET)_DATASET
+
 all:
-	gcc -O3 ${INCLUDE} ${LIBPATH} ${LIB} ${CFILES} -o ${EXECUTABLE}
+	gcc -O3 ${INCLUDE} ${LIBPATH} ${LIB} ${CFILES} -D${DATASET_MACRO} -o ${EXECUTABLE}
 
 clean:
 	rm -f *~ *.exe *.txt

--- a/OpenMP/utilities/common.mk
+++ b/OpenMP/utilities/common.mk
@@ -10,6 +10,9 @@ SRC += $(UTIL_DIR)/polybench.c
 DEPS        := Makefile.dep
 DEP_FLAG    := -MM
 
+DATASET ?= STANDARD
+DATASET_MACRO := $(DATASET)_DATASET
+
 .PHONY: all exe clean veryclean
 
 all : exe
@@ -17,7 +20,7 @@ all : exe
 exe : $(EXE)
 
 $(EXE) : $(SRC)
-	$(ACC) $(ACCFLAGS) $(CC) $(CFLAGS) $(INCPATHS) $^ -o $@
+	$(ACC) $(ACCFLAGS) $(CC) $(CFLAGS) -D${DATASET_MACRO} $(INCPATHS) $^ -o $@
 
 clean :
 	-rm -vf __hmpp* -vf $(EXE) *~ 
@@ -26,6 +29,6 @@ veryclean : clean
 	-rm -vf $(DEPS)
 
 $(DEPS): $(SRC) $(HEADERS)
-	$(CC) $(INCPATHS) $(DEP_FLAG) $(SRC) > $(DEPS)
+	$(CC) $(INCPATHS) $(DEP_FLAG) -D${DATASET_MACRO} $(SRC) > $(DEPS)
 
 -include $(DEPS)


### PR DESCRIPTION
## Description

This PR refactors dataset selection in the PolyBench build system to support configurable dataset sizes via macro concatenation, while preserving the existing PolyBench macro conventions.

Specifically, we separate the human-facing configuration from the compiler-facing macro name:

- `DATASET` specifies the dataset class (namely, `MINI`, `SMALL`, `STANDARD`, `LARGE`, `EXTRALARGE`)
- `DATASET_MACRO := $(DATASET)_DATASET` is passed to the compiler via the `-D` flag

This enables dataset selection through the command line, e.g.:

```bash
make DATASET=MINI
make DATASET=STANDARD
make DATASET=EXTRALARGE
```

which expands to the expected PolyBench macros (`-DMINI_DATASET`, etc.) during compilation.

## Changes

- Introduce `DATASET_MACRO` as the sole macro passed to the compiler
- Use `DATASET ?=` to allow safe command-line overrides
- Apply `-D$(DATASET_MACRO)` only at preprocessing-relevant compilation steps
- Minor fixes:
    -  Fixes #15 by updating `cudaDeviceSynchronize()`
    - add missing `-lm` flag for `linear-algebra/solvers/gramschmidt` and `datamining/correlation`, make `LDFLAGS` macro configurable

## Impact

This change does not modify kernel implementations or runtime behavior.
It only affects how dataset size is selected at build time, making the process explicit, robust, and script-friendly.
